### PR TITLE
[Feature] Add Build and Skip params for deploy script

### DIFF
--- a/actions/balance-filter/deploy.sh
+++ b/actions/balance-filter/deploy.sh
@@ -24,5 +24,3 @@ build
 
 $WSK_CLI -i --apihost "$openwhiskApiHost" action update ${ACTION} "$TEMP_DIR/main.zip" --docker "$DOCKER_IMAGE" \
 --auth "$openwhiskApiKey" --param push_notification_trigger "send-push-notification" --param db_url "http://admin:p@ssw0rd@172.17.0.1:5984" --param db_name "balance_filter_db" -a provide-api-key true
-
-clear_temp

--- a/actions/balance-notification-registration/deploy.sh
+++ b/actions/balance-notification-registration/deploy.sh
@@ -24,5 +24,3 @@ build
 
 $WSK_CLI -i --apihost "$openwhiskApiHost" action update ${ACTION} "$TEMP_DIR/main.zip" --docker "$DOCKER_IMAGE" \
 --auth "$openwhiskApiKey" --param event_registration_db "event_registration_db" --param balance_filter_db "balance_filter_db" --param db_name "balance_notification_registration_db" --param db_url "http://admin:p@ssw0rd@172.17.0.1:5984" --web true
-
-clear_temp

--- a/actions/event-receiver/deploy.sh
+++ b/actions/event-receiver/deploy.sh
@@ -24,5 +24,3 @@ build
 
 $WSK_CLI -i --apihost "$openwhiskApiHost" action update ${ACTION} "$TEMP_DIR/main.zip" --docker "$DOCKER_IMAGE" \
 --auth "$openwhiskApiKey" -a provide-api-key true
-
-clear_temp

--- a/actions/event-registration/deploy.sh
+++ b/actions/event-registration/deploy.sh
@@ -24,5 +24,3 @@ build
 
 $WSK_CLI -i --apihost "$openwhiskApiHost" action update ${ACTION} "$TEMP_DIR/main.zip" --docker "$DOCKER_IMAGE" \
 --auth "$openwhiskApiKey" --param db_name "event_registration_db" --param db_url "http://admin:p@ssw0rd@172.17.0.1:5984" --param feed "kafka-provider-feed" --param brokers "[\"172.17.0.1:9092\"]" -a provide-api-key true
-
-clear_temp

--- a/actions/kafka-provider-feed/deploy.sh
+++ b/actions/kafka-provider-feed/deploy.sh
@@ -24,5 +24,3 @@ build
 
 $WSK_CLI -i --apihost "$openwhiskApiHost" action update ${ACTION} "$TEMP_DIR/main.zip" --kind nodejs:default \
 --auth "$openwhiskApiKey" -a feed true --param endpoint "http://172.17.0.1:8888" --param web_action "kafka-provider-web" -a provide-api-key true
-
-clear_temp

--- a/actions/kafka-provider-web/deploy.sh
+++ b/actions/kafka-provider-web/deploy.sh
@@ -24,5 +24,3 @@ build
 
 $WSK_CLI -i --apihost "$openwhiskApiHost" action update ${ACTION} "$TEMP_DIR/main.zip" --kind nodejs:default \
 --auth "$openwhiskApiKey" --param endpoint "http://172.17.0.1:8888" --param db_url "http://admin:p@ssw0rd@172.17.0.1:5984" --param db_name "ow_kafka_triggers" -a provide-api-key true --web true
-
-clear_temp

--- a/actions/push-notification/deploy.sh
+++ b/actions/push-notification/deploy.sh
@@ -28,5 +28,3 @@ $WSK_CLI -i --apihost "$openwhiskApiHost" action update ${ACTION} "$TEMP_DIR/mai
 
 $WSK_CLI -i --apihost "$openwhiskApiHost" trigger update "send-${ACTION}" --auth "$openwhiskApiKey"
 $WSK_CLI -i --apihost "$openwhiskApiHost" rule update "${ACTION}-rule" "send-${ACTION}" ${ACTION} --auth "$openwhiskApiKey"
-
-clear_temp

--- a/actions/substrate-event-processor/deploy.sh
+++ b/actions/substrate-event-processor/deploy.sh
@@ -27,5 +27,3 @@ $WSK_CLI -i --apihost "$openwhiskApiHost" action update ${ACTION} "$TEMP_DIR/mai
 
 $WSK_CLI -i --apihost "$openwhiskApiHost" trigger update "produce-event" --auth "$openwhiskApiKey"
 $WSK_CLI -i --apihost "$openwhiskApiHost" rule update "produce-event-rule" "produce-event" "event-producer" --auth "$openwhiskApiKey"
-
-clear_temp

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,13 +6,22 @@
 openwhiskApiHost=${openwhiskApiHost:-https://localhost:31001}
 openwhiskApiKey=${openwhiskApiKey:-23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP}
 openwhiskNamespace=${openwhiskNamespace:-guest}
+build=${build:-push-notification,balance-filter,event-receiver,event-registration,balance-notification-registration,event-producer,kafka-provider-feed,kafka-provider-web,substrate-event-processor}
+skip=${skip:-}
 
 actions=("actions/push-notification" "actions/balance-filter" "actions/event-receiver" "actions/event-registration" "actions/balance-notification-registration" "actions/event-producer" "actions/kafka-provider-feed" "actions/kafka-provider-web" "actions/substrate-event-processor")
 
 source ./scripts/accept_params.sh
+source ./scripts/util.sh
+
+build_array=(${build//,/ })
+skip_array=(${skip//,/ })
 
 for index in ${!actions[@]};
 do  
-    chmod +x "$PWD/${actions[$index]}/deploy.sh"
-    "$PWD/${actions[$index]}/deploy.sh" --openwhiskApiHost "$openwhiskApiHost" --openwhiskApiKey "$openwhiskApiKey" --openwhiskNamespace "$openwhiskNamespace"
+    array_contains "${actions[$index]//actions\//}" "${skip_array[@]}" && true || {
+        array_contains "${actions[$index]//actions\//}" "${build_array[@]}" && should_build=true || should_build=false
+        chmod +x "$PWD/${actions[$index]}/deploy.sh"
+        "$PWD/${actions[$index]}/deploy.sh" --openwhiskApiHost "$openwhiskApiHost" --openwhiskApiKey "$openwhiskApiKey" --openwhiskNamespace "$openwhiskNamespace" --build $should_build
+    }
 done

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,3 +48,32 @@ Organization space where the actions to be deployed
 ./deploy.sh --openwhiskNamespace guest
 ```
 
+###
+
+### Build Action
+
+Provide actions to be build, Accepts `none` or name of the actions separated by `,` to be build
+
+| Parameter | Default Value |
+| :--- | :--- |
+| --build | push-notification,balance-filter,event-receiver,event-registration,balance-notification-registration,event-producer,kafka-provider-feed,kafka-provider-web,substrate-event-processor |
+
+#### usage
+
+```text
+./deploy.sh --build push-notification
+```
+
+### Skip Build and Deploy Action
+
+Provide actions to be skip, Accepts name of the available actions separated by `,`
+
+| Parameter | Default Value |
+| :--- | :--- |
+| --skip | none |
+
+#### usage
+
+```text
+./deploy.sh --skip push-notification,balance-filter
+```

--- a/scripts/build_js_action.sh
+++ b/scripts/build_js_action.sh
@@ -1,16 +1,18 @@
-if [ -e $TEMP_DIR ]; then
-    echo "Clearing previously packed action files."
-    rm -rf $TEMP_DIR
+if [ "$build" = true ]; then
+    if [ -e $TEMP_DIR ]; then
+        echo "Clearing previously packed action files."
+        rm -rf $TEMP_DIR
+    fi
+    
+    mkdir -p $TEMP_DIR
+    echo "Creating temporary directory"
+    
+    echo "Copying files to temporary directory"
+    cp -r "$SRC_DIR/package.json" "$SRC_DIR/lib" "$SRC_DIR/main.js" $TEMP_DIR
+    
+    cd $TEMP_DIR
+    
+    yarn install --production=true
+    
+    zip -r "$TEMP_DIR/main.zip" *
 fi
-
-mkdir -p $TEMP_DIR
-echo "Creating temporary directory"
-
-echo "Copying files to temporary directory"
-cp -r "$SRC_DIR/package.json" "$SRC_DIR/lib" "$SRC_DIR/main.js" $TEMP_DIR
-
-cd $TEMP_DIR
-
-yarn install --production=true
-
-zip -r "$TEMP_DIR/main.zip" *

--- a/scripts/build_rust_action.sh
+++ b/scripts/build_rust_action.sh
@@ -1,17 +1,17 @@
 DOCKER_IMAGE="hugobyte/openwhisk-runtime-rust:v0.2"
 
-if [ -e $TEMP_DIR ]; then
-    echo "Clearing previously packed action files."
-    rm -rf $TEMP_DIR
+if [ "$build" = true ]; then
+    if [ -e $TEMP_DIR ]; then
+        echo "Clearing previously packed action files."
+        rm -rf $TEMP_DIR
+    fi
+    
+    mkdir -p $TEMP_DIR
+    echo "Creating temporary directory"
+    
+    echo "Building Source to $TEMP_DIR/main.zip"
+    
+    cd $SRC_DIR
+    
+    zip -r - Cargo.toml src | docker run -e RELEASE=true -i --rm $DOCKER_IMAGE -compile main > "$TEMP_DIR/main.zip"
 fi
-
-mkdir -p $TEMP_DIR
-echo "Creating temporary directory"
-
-echo "Building Source to $TEMP_DIR/main.zip"
-
-cd $SRC_DIR
-
-zip -r - Cargo.toml src | docker run -e RELEASE=true -i --rm $DOCKER_IMAGE -compile main > "$TEMP_DIR/main.zip"
-
-cd $TEMP_DIR

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -1,0 +1,11 @@
+array_contains () {
+    local seeking=$1; shift
+    local in=1
+    for element; do
+        if [[ $element == "$seeking" ]]; then
+            in=0
+            break
+        fi
+    done
+    return $in
+}


### PR DESCRIPTION
### Description
- Add flag --build which defaults to name of the actions separated by commas
- Add flag --skip which accepts the name of the actions separated by commas to skip executing deploying the provided actions
- Prevent removing previous builds
- Closes #12 

### Usage
Scenario 1: Deploy all actions with previous builds
command: ./deploy.sh --build none

Scenario 2: Build only a certain action and rest actions to use previous builds
command: ./deploy.sh --build "balance-filter"

Scenario 3: Build only certain actions and rest actions to use previous builds
command: ./deploy.sh --build "balance-filter,push-notification"

Scenario 4: Skip building and deploying certain actions
command: ./deploy.sh --skip "balance-filter,push-notification"

Scenario 5: Build only certain actions and Skip certain actions to be build and deployed
command: ./deploy.sh --build "balance-filter,push-notification" --skip "event-registration"
